### PR TITLE
Fix XMLHTTPMessageTest (Request|Response)

### DIFF
--- a/src/XML-Parser-Tests/XMLHTTPMessageTest.class.st
+++ b/src/XML-Parser-Tests/XMLHTTPMessageTest.class.st
@@ -101,6 +101,9 @@ XMLHTTPMessageTest >> testAddHeader [
 			assertMessage: message
 			hasHeaders: addedHeaders].
 
+	SystemVersion current major >= 10
+		ifFalse: [^ self].
+
 	self headers do: [:each |
 		self assert: (message addHeader: each) equals: each.
 		self
@@ -504,6 +507,9 @@ XMLHTTPMessageTest >> testHeaderValuesAtAdd [
 		self
 			assertMessage: message
 			hasHeaders: addedHeaders].
+
+	SystemVersion current major >= 10
+		ifFalse: [^ self].
 
 	self headers do: [:each |
 		self assert:

--- a/src/XML-Parser-Tests/XMLHTTPMessageTest.class.st
+++ b/src/XML-Parser-Tests/XMLHTTPMessageTest.class.st
@@ -25,7 +25,7 @@ XMLHTTPMessageTest >> assertMessage: aMessage hasHeaders: anAssociationCollectio
 	"use #associationsDo: to support Dictionaries and SequenceableCollections"
 	anAssociationCollection associationsDo: [:each |
 		addedHeaders add: each].
-	self assert: aMessage headers sorted = addedHeaders sorted.
+	self assert: aMessage headers sorted equals: addedHeaders sorted
 ]
 
 { #category : #accessing }
@@ -95,18 +95,17 @@ XMLHTTPMessageTest >> testAddHeader [
 	self headers do: [:each |
 		self deny: (message headers includes: each).
 
-		self assert: (message addHeader: each) = each.
+		self assert: (message addHeader: each) equals: each.
 		addedHeaders addLast: each.
 		self
 			assertMessage: message
 			hasHeaders: addedHeaders].
 
 	self headers do: [:each |
-		self assert: (message addHeader: each) = each.
-		addedHeaders addLast: each.
+		self assert: (message addHeader: each) equals: each.
 		self
 			assertMessage: message
-			hasHeaders: addedHeaders].
+			hasHeaders: addedHeaders]
 ]
 
 { #category : #tests }
@@ -500,7 +499,7 @@ XMLHTTPMessageTest >> testHeaderValuesAtAdd [
 		self assert:
 			(message
 				headerValuesAt: each key
-				add: each value) = each value.
+				add: each value) equals: each value.
 		addedHeaders addLast: each.
 		self
 			assertMessage: message
@@ -510,11 +509,10 @@ XMLHTTPMessageTest >> testHeaderValuesAtAdd [
 		self assert:
 			(message
 				headerValuesAt: each key
-				add: each value) = each value.
-		addedHeaders addLast: each.
+				add: each value) equals: each value.
 		self
 			assertMessage: message
-			hasHeaders: addedHeaders].
+			hasHeaders: addedHeaders]
 ]
 
 { #category : #tests }


### PR DESCRIPTION
Fix XMLHTTPMessageTest (Request|Response) testAddHeader and testHeaderValuesAtAdd tests by not adding to the addedHeaders collection the second time

Listen to some code critics